### PR TITLE
Use string.h instead of memory.h

### DIFF
--- a/src/mrb_sqlite3.c
+++ b/src/mrb_sqlite3.c
@@ -1,5 +1,5 @@
 #include <errno.h>
-#include <memory.h>
+#include <string.h>
 #include <mruby.h>
 #include <mruby/proc.h>
 #include <mruby/data.h>


### PR DESCRIPTION
memory.h is not listed on C99 standard header files.
