### PR TITLE
nil binding should be treated as sql null

### DIFF
--- a/src/mrb_sqlite3.c
+++ b/src/mrb_sqlite3.c
@@ -111,9 +111,6 @@ bind_values(mrb_state* mrb, sqlite3* db, sqlite3_stmt* stmt, int argc, mrb_value
   for (i = 0; i < argc; i++) {
     int rv = SQLITE_MISMATCH;
     switch (mrb_type(argv[i])) {
-    case MRB_TT_UNDEF:
-      rv = sqlite3_bind_null(stmt, i+1);
-      break;
     case MRB_TT_STRING:
       rv = sqlite3_bind_text(stmt, i+1, RSTRING_PTR(argv[i]), RSTRING_LEN(argv[i]), NULL);
       break;
@@ -127,7 +124,11 @@ bind_values(mrb_state* mrb, sqlite3* db, sqlite3_stmt* stmt, int argc, mrb_value
       rv = sqlite3_bind_int(stmt, i+1, 1);
       break;
     case MRB_TT_FALSE:
-      rv = sqlite3_bind_int(stmt, i+1, 0);
+      if (mrb_nil_p(argv[i])) {
+        rv = sqlite3_bind_null(stmt, i+1);
+      } else {
+        rv = sqlite3_bind_int(stmt, i+1, 0);
+      }
       break;
     default:
       return "invalid argument";

--- a/test/sqlite3_test.rb
+++ b/test/sqlite3_test.rb
@@ -53,3 +53,14 @@ assert('transaction long') do
   db.close
   s == 100
 end
+
+assert('bind nil') do
+  db = SQLite3::Database.new('mruby-sqlite-test.db')
+  db.execute_batch('insert into bar(text) values(?)', nil)
+  s = true
+  db.execute('select text from bar order by id desc limit 1 offset 0') do |row, fields|
+    s = row[0]
+  end
+  db.close
+  s.nil?
+end


### PR DESCRIPTION
mruby's nil is MRB_TT_FALSE, not MRB_TT_UNDEF, so binding nil is treated as false, then it'll be bind as 0.
"/\* {MRB_TT_UNDEF, "undef"}, _/ /_ internal use: #undef; should not happen */" https://github.com/mruby/mruby/blob/444e4b7976d629663d1020de65280e01853a2ca4/src/object.c
